### PR TITLE
Fix README installation instructions for Gatsby v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ Adds ESLint to your Gatsby dev environment, maintaining code quality as you deve
 
 1. Install the `gatsby-plugin-eslint` plugin:
 
-    `npm install --save-dev gatsby-plugin-eslint`
+    `npm install --save-dev gatsby-plugin-eslint eslint-loader`
 
     or
 
-    `yarn add --dev gatsby-plugin-eslint`
+    `yarn add --dev gatsby-plugin-eslint eslint-loader`
 
 ### Gatsby V1 Instructions
 1. Install the `gatsby-plugin-eslint` plugin:


### PR DESCRIPTION
Gatsby v2 requires you to install all peer dependencies.
https://www.gatsbyjs.org/docs/migrating-from-v1-to-v2/#manually-install-plugins-peer-dependencies

This change fixes the documentation to notify users to also install `eslint-loader`