### PR TITLE
Enforce loader to run at start

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -9,6 +9,7 @@ exports.onCreateWebpackConfig = ({ stage, actions }, pluginOptions) => {
       module: {
         rules: [
           {
+            enforce: "pre",
             test: test,
             loader: "eslint-loader",
             exclude: exclude,


### PR DESCRIPTION
For me the eslint-loader used in thin plugin would run after the typescript plugin which messed up all the formatting. This will PR will enforce the eslint-loader to run at the start of compilation.