### PR TITLE
Allow specification of webpack "include" option

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -1,6 +1,6 @@
 exports.onCreateWebpackConfig = ({ stage, actions }, pluginOptions) => {
   const test = pluginOptions.test || /\.js$|\.jsx$/;
-  const exclude = pluginOptions.exclude || /(node_modules|.cache|public)/;
+  const exclude = pluginOptions.exclude || /(node_modules|\.cache|public)/;
   const options = pluginOptions.options || {};
   const stages = pluginOptions.stages || ['develop'];
 

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -12,6 +12,7 @@ exports.onCreateWebpackConfig = ({ stage, actions }, pluginOptions) => {
             enforce: "pre",
             test: test,
             loader: "eslint-loader",
+            include: pluginOptions.include,
             exclude: exclude,
             options
           }


### PR DESCRIPTION
ESLint / Webpack allows users to set the [rule.include](https://webpack.js.org/configuration/module/#ruleinclude) option. It seems like reasonable behaviour to support this.