### PR TITLE
Fixes issue with pluginOptions

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -1,7 +1,7 @@
 const ESLintPlugin = require("eslint-webpack-plugin");
 
 exports.onCreateWebpackConfig = ({ stage, actions }, pluginOptions) => {
-  const options = pluginOptions.options || {};
+  const options = pluginOptions || {};
   if (!options.extensions) options.extensions = ["js", "jsx", "ts", "tsx"];
   if (!options.exclude) options.exclude = ["node_modules", ".cache", "public"];
 


### PR DESCRIPTION
This fixes an issue were the code is assuming that pluginOptions has a property `options` as set from gatsby-config.js. However, pluginOptions *IS* the `options` from the config, so no need to use `pluginOptions.options`.

- Closes #26