### PR TITLE
fix: Set correct peerDependency on gatsby

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
   "peerDependencies": {
     "eslint": "^7.18.0",
     "eslint-webpack-plugin": "^2.4.3",
-    "gatsby": ">=2"
+    "gatsby": "^3.0.0 || ^2.0.0"
   }
 }


### PR DESCRIPTION
Hello @mongkuen, Gatsby maintainer here 👋 
First and foremost, thanks for creating the plugin & maintaining it. Much appreciated!

While looking at your plugin I noticed that the `peerDependency` on `gatsby` is set incorrectly. We're in the process of providing more helpful information on the `/plugins` page of our website and for that we need plugins to set their `peerDependencies` correctly/more specific.

At the moment you say that _any_ version (v3, v4, v5, v6, etc.) will work with this even when in between we'd introduce breaking changes.

Making it more explicit is the safer choice (in the future you'll be able to mark breaking changes with explicit version ranges) and will allow us to display the plugin as compatible to versions X, Y, Z.

Thanks!